### PR TITLE
Make available to other GitHub organizations

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
-# Replace [REPO NAME]
+# Replace [ORG NAME] and [REPO NAME]
 
 blank_issues_enabled: false
 contact_links:
   - name: Feature request
-    url: https://github.com/route06inc/[REPO NAME]/discussions/categories/ideas
+    url: https://github.com/[ORG NAME]/[REPO NAME]/discussions/categories/ideas
     about: Share ideas for new features
   - name: Ask a question
-    url: https://github.com/route06inc/[REPO NAME]/discussions/categories/q-a
+    url: https://github.com/[ORG NAME]/[REPO NAME]/discussions/categories/q-a
     about: Ask questions and discuss with other community members

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-<!-- Replace [REPO NAME] and complete [TODO] -->
+<!-- Replace [ORG NAME] and [REPO NAME], complete [TODO] -->
 
 # Contributing
 
@@ -23,7 +23,7 @@ To set up a development environment, please follow these steps:
 1. Clone the repo
 
    ```sh
-   git clone https://github.com/route06inc/[REPO NAME]
+   git clone https://github.com/[ORG NAME]/[REPO NAME]
    ```
 
 2. [TODO]
@@ -32,11 +32,11 @@ To set up a development environment, please follow these steps:
 
 <!-- If GitHub Discussions is enable: -->
 
-You've found a bug in the source code, a mistake in the documentation or maybe you'd like a new feature? Take a look at [GitHub Discussions](https://github.com/route06inc/[REPO NAME]/discussions) to see if it's already being discussed. You can help us by [submitting an issue on GitHub](https://github.com/route06inc/[REPO NAME]/issues). Before you create an issue, make sure to search the issue archive -- your issue may have already been addressed!
+You've found a bug in the source code, a mistake in the documentation or maybe you'd like a new feature? Take a look at [GitHub Discussions](https://github.com/[ORG NAME]/[REPO NAME]/discussions) to see if it's already being discussed. You can help us by [submitting an issue on GitHub](https://github.com/[ORG NAME]/[REPO NAME]/issues). Before you create an issue, make sure to search the issue archive -- your issue may have already been addressed!
 
 <!-- Else: -->
 
-You've found a bug in the source code, a mistake in the documentation or maybe you'd like a new feature? You can help us by [submitting an issue on GitHub](https://github.com/route06inc/[REPO NAME]/issues). Before you create an issue, make sure to search the issue archive -- your issue may have already been addressed!
+You've found a bug in the source code, a mistake in the documentation or maybe you'd like a new feature? You can help us by [submitting an issue on GitHub](https://github.com/[ORG NAME]/[REPO NAME]/issues). Before you create an issue, make sure to search the issue archive -- your issue may have already been addressed!
 
 <!-- Endif -->
 
@@ -51,9 +51,9 @@ Please try to create bug reports that are:
 
 ### How to submit a Pull Request
 
-1. Search our repository for open or closed [Pull Requests](https://github.com/route06inc/[REPO NAME]/pulls) that relate to your submission. You don't want to duplicate effort.
+1. Search our repository for open or closed [Pull Requests](https://github.com/[ORG NAME]/[REPO NAME]/pulls) that relate to your submission. You don't want to duplicate effort.
 2. Fork the project
 3. Create your feature branch (`git switch -c feat/amazing_feature`)
 4. Commit your changes (`git commit -m 'feat: add amazing_feature'`)
 5. Push to the branch (`git push origin feat/amazing_feature`)
-6. [Open a Pull Request](https://github.com/route06inc/[REPO NAME]/compare?expand=1)
+6. [Open a Pull Request](https://github.com/[ORG NAME]/[REPO NAME]/compare?expand=1)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,11 +33,11 @@ If you discover a security vulnerability, please report it to us in the followin
 
 ### case2: Report via GitHub Private vulnerability reporting
 
-<!-- Replace [REPO NAME] -->
+<!-- Replace [ORG NAME] and [REPO NAME] -->
 
 Out team and community take security bugs in seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
 
-To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/route06inc/[REPO NAME]/security/advisories/new) tab. **Do not open up a GitHub issue.**
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/[ORG NAME]/[REPO NAME]/security/advisories/new) tab. **Do not open up a GitHub issue.**
 
 Our team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
 


### PR DESCRIPTION
GitHub repository templates are available to other organizations.

I have updated it so that it can also be used when creating repositories for organizations such as https://github.com/giselles-ai.