### PR TITLE
Add permissions to Dependency Review workflow

### DIFF
--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -2,6 +2,10 @@ name: Dependency Review
 
 on: [pull_request]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   dependency_review:
     uses: route06/actions/.github/workflows/dependency_review.yml@v2


### PR DESCRIPTION
Starting with [v2.6.0](https://github.com/route06/actions/releases/tag/v2.6.0), when the Dependency Review workflow finds a vulnerability in package(s), it comments to the PR. This requires the `pull-requests: write` permission.

* https://github.com/route06/actions/compare/v2.5.0...v2.6.0#diff-b9f47e37d4a1d43713e4fbbcabc7d235e73b49f86b56ba378e9211e751e94869

If you do not grant this permission, the behavior will remain as before. You will need to check the summary of failed jobs.
